### PR TITLE
feat: 테스트 서버 CI/CD 자동화

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -66,7 +66,7 @@ jobs:
           host: ${{ secrets.EC2_DEV_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_DEV_KEY }}
-          envs: ECR_IMAGE_NAME, IMAGE_TAG, AWS_ACCOUNT
+          envs: IMAGE_NAME, IMAGE_TAG, AWS_ACCOUNT
           script: |
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin $AWS_ACCOUNT
             docker pull $IMAGE_NAME:$IMAGE_TAG

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -28,7 +28,9 @@ jobs:
         uses: gradle/gradle-build-action@v2
     
       - name: Gradle 빌드
-        run: ./meongcare/gradlew build
+        run: |
+          cd ./meongcare
+          ./gradlew build
 
       - name: AWS Configure 설정
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -24,6 +24,9 @@ jobs:
         env:
           APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
 
+      - name: Gradle 빌드 권한 부여
+        run: chmod +x gradlew
+      
       - name: Gradle 빌드
         run: ./meongcare/gradlew build
 

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -50,6 +50,7 @@ jobs:
           ECR_REPOSITORY: meongcare
           IMAGE_TAG: ${{ github.sha }}
         run: |
+          cd ./meongcare
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "IMAGE_NAME=$ECR_REGISTRY/$ECR_REPOSITORY" >> $GITHUB_OUTPUT

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -82,4 +82,4 @@ jobs:
             docker image tag $IMAGE_NAME:$IMAGE_TAG meongcare/dev
             chmod 777 ./deploy.sh
             ./deploy.sh
-            docker image prune -a
+            docker image prune -f

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -9,6 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Gradle 캐싱
+        uses: actions/cache@v3
+        with:
+          path: |  
+              ~/.gradle/caches
+              ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
       - uses: actions/checkout@v3
       - name: java코드 빌드 jdk 11 설정
         uses: actions/setup-java@v3

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: application.yml 생성
         run: |
-          cd ./src/main/resources 
+          cd ./meongcare/src/main/resources 
           touch ./application.yml 
           echo "$APPLICATION_DEV" > ./application.yml
         env:

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -28,7 +28,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
     
       - name: Gradle 빌드
-        run: ./gradlew build
+        run: ./meongcare/gradlew build
 
       - name: AWS Configure 설정
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -54,7 +54,7 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "IMAGE_NAME=$ECR_REGISTRY/$ECR_REPOSITORY" >> $GITHUB_OUTPUT
-          echo "IMAGE_TAG=$IMAGE_TAG" >> @GITHUB_OUTPUT
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: ECR image pull & blue-green 배포 스크립트 실행
         uses: appleboy/ssh-action@master

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -25,7 +25,7 @@ jobs:
           APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
 
       - name: Gradle 빌드
-        run: ./meongcare/gradlew build -x test
+        run: ./meongcare/gradlew build
 
       - name: AWS Configure 설정
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ "feature/6" ]
+    branches: [ "develop" ]
 
 jobs:
   CI-CD:
@@ -52,7 +52,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: docker 빌드 및 ECR 푸시
+      - name: docker 빌드 및 ECR push
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -73,4 +73,4 @@ jobs:
             docker image tag $IMAGE_NAME:$IMAGE_TAG meongcare/dev
             chmod 777 ./deploy.sh
             ./deploy.sh
-            docker image prune
+            docker image prune -a

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -23,12 +23,12 @@ jobs:
           echo "$APPLICATION_DEV" > ./application.yml
         env:
           APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
-
-      - name: Gradle 빌드 권한 부여
-        run: chmod +x gradlew
       
+      - name: Gradle 셋업
+        uses: gradle/gradle-build-action@v2
+    
       - name: Gradle 빌드
-        run: ./meongcare/gradlew build
+        run: ./gradlew build
 
       - name: AWS Configure 설정
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -25,7 +25,7 @@ jobs:
           APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
 
       - name: Gradle 빌드
-        run: ./gradlew build -x test
+        run: ./meongcare/gradlew build -x test
 
       - name: AWS Configure 설정
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -1,0 +1,70 @@
+name: CI/CD 
+
+on:
+  push:
+    branches: [ "feature/6" ]
+
+jobs:
+  CI-CD:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+      - name: java코드 빌드 jdk 11 설정
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: application.yml 생성
+        run: |
+          cd ./src/main/resources 
+          touch ./application.yml 
+          echo "$APPLICATION_DEV" > ./application.yml
+        env:
+          APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
+
+      - name: Gradle 빌드
+        run: ./gradlew build -x test
+
+      - name: AWS Configure 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: ECR 로그인
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: docker 빌드 및 ECR 푸시
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: meongcare
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "IMAGE_NAME=$ECR_REGISTRY/$ECR_REPOSITORY" >> $GITHUB_OUTPUT
+          echo "IMAGE_TAG=$IMAGE_TAG" >> @GITHUB_OUTPUT
+
+      - name: ECR image pull & blue-green 배포 스크립트 실행
+        uses: appleboy/ssh-action@master
+        env: 
+          IMAGE_NAME : ${{ steps.build-image.outputs.IMAGE_NAME}}
+          IMAGE_TAG : ${{ steps.build-image.outputs.IMAGE_TAG}}
+          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+        with:
+          host: ${{ secrets.EC2_DEV_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_DEV_KEY }}
+          envs: ECR_IMAGE_NAME, IMAGE_TAG, AWS_ACCOUNT
+          script: |
+            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin $AWS_ACCOUNT
+            docker pull $IMAGE_NAME:$IMAGE_TAG
+            docker image tag $IMAGE_NAME:$IMAGE_TAG meongcare/dev
+            chmod 777 ./deploy.sh
+            ./deploy.sh
+            docker image prune

--- a/meongcare/Dockerfile
+++ b/meongcare/Dockerfile
@@ -1,0 +1,3 @@
+FROM adoptopenjdk/openjdk11:ubi
+COPY build/libs/meongcare-0.0.1-SNAPSHOT.jar app.jar
+CMD ["java", "-jar", "app.jar"]

--- a/meongcare/build.gradle
+++ b/meongcare/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	//querydsl
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+	//actuator
+	implementation('org.springframework.boot:spring-boot-starter-actuator')
 }
 
 tasks.named('test') {

--- a/meongcare/docker-compose.yml
+++ b/meongcare/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3"
+services:
+  blue:
+    image: meongcare/dev
+    container_name: blue
+    ports:
+      - 8081:8080
+
+  green:
+    image: meongcare/dev
+    container_name: green
+    ports:
+      - 8082:8080
+
+  redis:
+    image: redis:alpine
+    container_name: redis
+    command: redis-server --port 6379
+    hostname: redis
+    ports:
+      - 6379:6379

--- a/meongcare/src/main/java/com/meongcare/MeongcareApplication.java
+++ b/meongcare/src/main/java/com/meongcare/MeongcareApplication.java
@@ -5,7 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-@SpringBootApplication
+@SpringBootApplication(
+		exclude = {
+				org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration.class,
+				org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration.class,
+				org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration.class
+		}
+)
 public class MeongcareApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## Description
- 테스트 서버 CI/CD 자동화하기

## ToDo
- [x] github Actions CI/CD 워크플로우 생성
- [x] 도커 빌드/배포 환경 구축

## ETC
- blue green 배포 방식으로 cicd 구축
- AWS ECR 사용해서 도커 이미지 private 저장
- deploy.sh, nginx.conf는 ec2에 저장해서 사용합니다.
