### PR TITLE
fix: 몸무게 데이터 추가 로직 수정

### DIFF
--- a/meongcare/src/main/java/com/meongcare/domain/weight/application/WeightService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/weight/application/WeightService.java
@@ -84,10 +84,11 @@ public class WeightService {
 
         if (Objects.nonNull(kg)) {
             weights.get(TODAY_WEIGHT).modifyWeight(kg);
+//            강아지 수정 API의 로직이 포함되어 있기에 일단 주석 처리 후 향후 문제 없을 시 제거 예정
+//            Dog dog = dogRepository.getById(dogId);
+//            dog.updateWeight(kg);
         }
         weightJdbcRepository.saveWeight(weights);
-        Dog dog = dogRepository.getById(dogId);
-        dog.updateWeight(kg);
     }
 
     public GetDayWeightResponse getDayWeight(Long dogId, LocalDate date) {

--- a/meongcare/src/main/java/com/meongcare/domain/weight/domain/repository/WeightQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/weight/domain/repository/WeightQueryRepository.java
@@ -69,7 +69,7 @@ public class WeightQueryRepository {
                 ))
                 .from(weight)
                 .where(dogIdEq(dogId),
-                        dateTimeLt(date)
+                        dateLt(date)
                 )
                 .orderBy(weight.date.desc())
                 .fetchFirst();
@@ -100,7 +100,7 @@ public class WeightQueryRepository {
         return weight.date.eq(date);
     }
 
-    private BooleanExpression dateTimeLt(LocalDate date) {
+    private BooleanExpression dateLt(LocalDate date) {
         return weight.date.lt(date);
     }
 


### PR DESCRIPTION
몸무게 데이터 추가 로직 수행 시
강아지 테이블의 몸무게를 수정하는 부분은  강아지 수정 API에서 수행하는 것을 확인했기에
해당 부분 주석 처리