### PR TITLE
[FIX] getById() 삭제된 데이터는 조회 안되게 수정 (#106)

### DIFF
--- a/meongcare/src/main/java/com/meongcare/domain/dog/application/DogService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/dog/application/DogService.java
@@ -43,19 +43,19 @@ public class DogService {
 
     public GetDogsResponse getDogs(Long userId) {
         Member member = memberRepository.getActiveUser(userId);
-        List<Dog> dogs = dogRepository.findAllByMember(member);
+        List<Dog> dogs = dogRepository.findAllByMemberAndDeletedFalse(member);
         return GetDogsResponse.of(dogs);
     }
 
     public GetDogResponse getDog(Long dogId) {
-        Dog dog = dogRepository.getById(dogId);
+        Dog dog = dogRepository.getActiveDog(dogId);
         return GetDogResponse.from(dog);
 
     }
 
     @Transactional
     public void updateDog(MultipartFile multipartFile, PutDogRequest putDogRequest, Long dogId) {
-        Dog dog = dogRepository.getById(dogId);
+        Dog dog = dogRepository.getActiveDog(dogId);
         String dogImageURL = imageHandler.uploadImage(multipartFile, ImageDirectory.DOG);
         dog.updateAll(putDogRequest, dogImageURL);
     }

--- a/meongcare/src/main/java/com/meongcare/domain/dog/domain/DogRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/dog/domain/DogRepository.java
@@ -11,15 +11,18 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DogRepository extends JpaRepository<Dog, Long> {
-    default Dog getById(Long id) {
-        return this.findById(id)
+    default Dog getActiveDog(Long id) {
+        return this.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.DOG_ENTITY_NOT_FOUND));
     }
 
-    List<Dog> findAllByMember(Member member);
+    Optional<Dog> findByIdAndDeletedFalse(Long id);
+
+    List<Dog> findAllByMemberAndDeletedFalse(Member member);
 
     @Modifying
     @Query("UPDATE Dog d SET d.deleted = true WHERE d.member.id = :memberId")

--- a/meongcare/src/main/java/com/meongcare/domain/medicalrecord/application/MedicalRecordService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/medicalrecord/application/MedicalRecordService.java
@@ -33,7 +33,7 @@ public class MedicalRecordService {
 
     @Transactional
     public void save(MultipartFile multipartFile, SaveMedicalRecordRequest saveMedicalRecordRequest) {
-        Dog dog = dogRepository.getById(saveMedicalRecordRequest.getDogId());
+        Dog dog = dogRepository.getActiveDog(saveMedicalRecordRequest.getDogId());
         String imageURL = imageHandler.uploadImage(multipartFile, ImageDirectory.MEDICAL_RECORD);
 
         medicalRecordRepository.save(saveMedicalRecordRequest.toEntity(dog, imageURL));
@@ -63,7 +63,7 @@ public class MedicalRecordService {
     }
 
     public GetMedicalRecordsResponse getMedicalRecords(Long dogId, LocalDateTime dateTime) {
-        Dog dog = dogRepository.getById(dogId);
+        Dog dog = dogRepository.getActiveDog(dogId);
         List<GetMedicalRecordsVo> getMedicalRecordsVos = medicalRecordQueryRepository.getByDate(
                 dog,
                 LocalDateTimeUtils.createNowMidnight(dateTime),

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/application/SupplementsService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/application/SupplementsService.java
@@ -38,7 +38,7 @@ public class SupplementsService {
 
     @Transactional
     public void saveSupplements(SaveSupplementsRequest saveSupplementsRequest, MultipartFile multipartFile) {
-        Dog dog = dogRepository.getById(saveSupplementsRequest.getDogId());
+        Dog dog = dogRepository.getActiveDog(saveSupplementsRequest.getDogId());
         String imageURL = imageHandler.uploadImage(multipartFile, ImageDirectory.SUPPLEMENTS);
 
         Supplements supplements = saveSupplementsRequest.toSupplements(dog, imageURL);
@@ -81,20 +81,20 @@ public class SupplementsService {
     }
 
     public GetSupplementsInfoResponse getSupplementsInfo(Long supplementsId) {
-        Supplements supplements = supplementsRepository.getById(supplementsId);
+        Supplements supplements = supplementsRepository.getActiveSupplement(supplementsId);
         List<SupplementsTime> supplementsTimes = supplementsTimeRepository.findAllBySupplementsId(supplementsId);
         return GetSupplementsInfoResponse.of(supplements, supplementsTimes);
     }
 
     @Transactional
     public void stopSupplementsRoutine(Long supplementsId, boolean isActive) {
-        Supplements supplements = supplementsRepository.getById(supplementsId);
+        Supplements supplements = supplementsRepository.getActiveSupplement(supplementsId);
         supplements.updateActive(isActive);
     }
 
     @Transactional
     public void deleteSupplements(Long supplementsId) {
-        Supplements supplements = supplementsRepository.getById(supplementsId);
+        Supplements supplements = supplementsRepository.getActiveSupplement(supplementsId);
         deleteSupplementsTimes(supplementsId);
         supplements.delete();
     }
@@ -102,7 +102,7 @@ public class SupplementsService {
     @Transactional
     public void deleteSupplements(List<Long> supplementsIds) {
         for (Long supplementsId : supplementsIds) {
-            Supplements supplements = supplementsRepository.getById(supplementsId);
+            Supplements supplements = supplementsRepository.getActiveSupplement(supplementsId);
             supplements.delete();
             deleteSupplementsTimes(supplementsId);
         }
@@ -110,16 +110,11 @@ public class SupplementsService {
 
     private void deleteSupplementsTimes(Long supplementsId) {
         supplementsTimeRepository.deleteBySupplementsId(supplementsId);
-
-//        List<SupplementsTime> allBySupplementsId = supplementsTimeRepository.findAllBySupplementsId(supplementsId);
-//        for (SupplementsTime supplementsTime : allBySupplementsId) {
-//            supplementsTime.delete();
-//        }
     }
 
     @Transactional
     public void updatePushAgreement(Long supplementsId, boolean pushAgreement) {
-        Supplements supplements = supplementsRepository.getById(supplementsId);
+        Supplements supplements = supplementsRepository.getActiveSupplement(supplementsId);
         supplements.updatePushAgreement(pushAgreement);
     }
 
@@ -146,7 +141,7 @@ public class SupplementsService {
     }
 
     private GetSupplementsRoutineResponse createAfterRecord(LocalDate date, Long dogId) {
-        List<Supplements> supplements = supplementsRepository.findAllByDogId(dogId);
+        List<Supplements> supplements = supplementsRepository.findAllByDogIdAndDeletedFalse(dogId);
         List<GetSupplementsRoutineWithoutStatusVO> getSupplementsRoutineWithoutStatusVOs = new ArrayList<>();
         for (Supplements supplementInfo : supplements) {
             if (checkIntakeDate(supplementInfo.getStartDate(), date, supplementInfo.getIntakeCycle())) {

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRepository.java
@@ -7,15 +7,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SupplementsRepository extends JpaRepository<Supplements, Long> {
-    List<Supplements> findAllByDogId(Long dogId);
 
     List<Supplements> findAllByDogIdAndDeletedFalse(Long dogId);
-    default Supplements getById(Long dogId){
-        return this.findById(dogId)
+    default Supplements getActiveSupplement(Long dogId){
+        return this.findByIdAndDeletedFalse(dogId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.SUPPLEMENTS_ENTITY_NOT_FOUND));
     }
+
+    Optional<Supplements> findByIdAndDeletedFalse(Long supplementId);
 
 }


### PR DESCRIPTION
### ✅ 작업한 내용
- 강아지, 영양제의 getById() 삭제 데이터 조회 안되게 수정했습니다 
- 나중에 where 조건이 많아지면 query dsl로 바꿔도 좋을 것 같네요..!


### ✅ 관련 이슈
- Resolved: #106 
