### PR TITLE
[FEAT] Logback으로 로그 저장, sentry 모니터링 #90

### DIFF
--- a/meongcare/build.gradle
+++ b/meongcare/build.gradle
@@ -67,6 +67,10 @@ dependencies {
 
 	//sentry
 	implementation 'io.sentry:sentry-spring-boot-starter:7.2.0'
+	implementation 'io.sentry:sentry-logback:6.28.0'
+
+	//logback
+	implementation "com.github.maricn:logback-slack-appender:1.4.0"
 }
 
 tasks.named('test') {

--- a/meongcare/src/main/java/com/meongcare/common/error/ErrorCode.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
 
     // 5xx
     FAILED_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "파일이 업로드되지 않았습니다."),
+    FAILED_MESSAGE_SEND(HttpStatus.INTERNAL_SERVER_ERROR, "알림 메세지 보내기를 실패했습니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다."),;
 
     private final HttpStatus httpStatus;

--- a/meongcare/src/main/java/com/meongcare/common/error/GlobalExceptionHandler.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/GlobalExceptionHandler.java
@@ -1,13 +1,13 @@
 package com.meongcare.common.error;
 
-import com.meongcare.common.error.exception.*;
+import com.meongcare.common.error.exception.clientError.BadRequestException;
+import com.meongcare.common.error.exception.serverError.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -15,8 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 public class GlobalExceptionHandler {
 
-    //validation 에러
-    @ExceptionHandler({BindException.class, MethodArgumentNotValidException.class})
+    @ExceptionHandler(BindException.class)
     public ResponseEntity<ErrorResponse> bindException(BindingResult bindingResult) {
         StringBuilder reason = new StringBuilder();
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
@@ -28,19 +27,26 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
-    @ExceptionHandler(BaseException.class)
-    protected ResponseEntity<ErrorResponse> baseException(BaseException e) {
+    @ExceptionHandler(BadRequestException.class)
+    protected ResponseEntity<ErrorResponse> badRequestException(BadRequestException e) {
         e.printStackTrace();
         log.warn("{} - {}", e.getClass().getSimpleName(), e.getMessage());
         final ErrorResponse errorResponse = new ErrorResponse(e.getHttpStatus(), e.getMessage());
         return ResponseEntity.status(e.getHttpStatus()).body(errorResponse);
     }
 
-
-    @ExceptionHandler(RuntimeException.class)
-    protected ResponseEntity<ErrorResponse> runtimeException(RuntimeException e) {
+    @ExceptionHandler(InternalServerException.class)
+    protected ResponseEntity<ErrorResponse> internalServerException(InternalServerException e) {
         e.printStackTrace();
-        log.warn("{} - {}", e.getClass().getSimpleName(), e.getMessage());
+        log.error("{} - {}", e.getClass().getSimpleName(), e.getMessage());
+        final ErrorResponse errorResponse = new ErrorResponse(e.getHttpStatus(), e.getMessage());
+        return ResponseEntity.status(e.getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> runtimeException(Exception e) {
+        e.printStackTrace();
+        log.error("{} - {}", e.getClass().getSimpleName(), e.getMessage());
         final ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }

--- a/meongcare/src/main/java/com/meongcare/common/error/GlobalExceptionHandler.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
@@ -29,24 +30,21 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
     protected ResponseEntity<ErrorResponse> badRequestException(BadRequestException e) {
-        e.printStackTrace();
-        log.warn("{} - {}", e.getClass().getSimpleName(), e.getMessage());
+        log.warn("[{}] {} ({})", e.getClass().getSimpleName(), e.getMessage(), e.getStackTrace()[0]);
         final ErrorResponse errorResponse = new ErrorResponse(e.getHttpStatus(), e.getMessage());
         return ResponseEntity.status(e.getHttpStatus()).body(errorResponse);
     }
 
     @ExceptionHandler(InternalServerException.class)
     protected ResponseEntity<ErrorResponse> internalServerException(InternalServerException e) {
-        e.printStackTrace();
-        log.error("{} - {}", e.getClass().getSimpleName(), e.getMessage());
+        log.error("[{}] {} ({})", e.getClass().getSimpleName(), e.getMessage(), e.getStackTrace()[0]);
         final ErrorResponse errorResponse = new ErrorResponse(e.getHttpStatus(), e.getMessage());
         return ResponseEntity.status(e.getHttpStatus()).body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> runtimeException(Exception e) {
-        e.printStackTrace();
-        log.error("{} - {}", e.getClass().getSimpleName(), e.getMessage());
+        log.error("[{}] {} ({})", e.getClass().getSimpleName(), e.getMessage(), e.getStackTrace()[0]);
         final ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }

--- a/meongcare/src/main/java/com/meongcare/common/error/exception/clientError/BadRequestException.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/exception/clientError/BadRequestException.java
@@ -1,0 +1,10 @@
+package com.meongcare.common.error.exception.clientError;
+
+import com.meongcare.common.error.ErrorCode;
+import com.meongcare.common.error.exception.BaseException;
+
+public class BadRequestException extends BaseException {
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/meongcare/src/main/java/com/meongcare/common/error/exception/clientError/EntityNotFoundException.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/exception/clientError/EntityNotFoundException.java
@@ -1,8 +1,8 @@
-package com.meongcare.common.error.exception;
+package com.meongcare.common.error.exception.clientError;
 
 import com.meongcare.common.error.ErrorCode;
 
-public class EntityNotFoundException extends BaseException{
+public class EntityNotFoundException extends BadRequestException {
     public EntityNotFoundException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/meongcare/src/main/java/com/meongcare/common/error/exception/clientError/InvalidTokenException.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/exception/clientError/InvalidTokenException.java
@@ -1,8 +1,8 @@
-package com.meongcare.common.error.exception;
+package com.meongcare.common.error.exception.clientError;
 
 import com.meongcare.common.error.ErrorCode;
 
-public class InvalidTokenException extends BaseException{
+public class InvalidTokenException extends BadRequestException {
 
     public InvalidTokenException(ErrorCode errorCode) {
         super(errorCode);

--- a/meongcare/src/main/java/com/meongcare/common/error/exception/clientError/UnauthorizedException.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/exception/clientError/UnauthorizedException.java
@@ -1,8 +1,8 @@
-package com.meongcare.common.error.exception;
+package com.meongcare.common.error.exception.clientError;
 
 import com.meongcare.common.error.ErrorCode;
 
-public class UnauthorizedException extends BaseException{
+public class UnauthorizedException extends BadRequestException {
     public UnauthorizedException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/meongcare/src/main/java/com/meongcare/common/error/exception/serverError/FailedFileUploadException.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/exception/serverError/FailedFileUploadException.java
@@ -1,8 +1,8 @@
-package com.meongcare.common.error.exception;
+package com.meongcare.common.error.exception.serverError;
 
 import com.meongcare.common.error.ErrorCode;
 
-public class FailedFileUploadException extends BaseException{
+public class FailedFileUploadException extends InternalServerException {
     public FailedFileUploadException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/meongcare/src/main/java/com/meongcare/common/error/exception/serverError/InternalServerException.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/exception/serverError/InternalServerException.java
@@ -1,0 +1,10 @@
+package com.meongcare.common.error.exception.serverError;
+
+import com.meongcare.common.error.ErrorCode;
+import com.meongcare.common.error.exception.BaseException;
+
+public class InternalServerException extends BaseException {
+    public InternalServerException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/meongcare/src/main/java/com/meongcare/common/error/exception/serverError/MessageException.java
+++ b/meongcare/src/main/java/com/meongcare/common/error/exception/serverError/MessageException.java
@@ -1,0 +1,10 @@
+package com.meongcare.common.error.exception.serverError;
+
+import com.meongcare.common.error.ErrorCode;
+
+public class MessageException extends InternalServerException{
+
+    public MessageException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/meongcare/src/main/java/com/meongcare/common/jwt/JwtService.java
+++ b/meongcare/src/main/java/com/meongcare/common/jwt/JwtService.java
@@ -1,7 +1,7 @@
 package com.meongcare.common.jwt;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.InvalidTokenException;
+import com.meongcare.common.error.exception.clientError.InvalidTokenException;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/meongcare/src/main/java/com/meongcare/common/jwt/JwtValidateArgumentResolver.java
+++ b/meongcare/src/main/java/com/meongcare/common/jwt/JwtValidateArgumentResolver.java
@@ -1,7 +1,7 @@
 package com.meongcare.common.jwt;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.InvalidTokenException;
+import com.meongcare.common.error.exception.clientError.InvalidTokenException;
 import lombok.AllArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;

--- a/meongcare/src/main/java/com/meongcare/domain/auth/application/AuthService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/auth/application/AuthService.java
@@ -1,8 +1,8 @@
 package com.meongcare.domain.auth.application;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.InvalidTokenException;
-import com.meongcare.common.error.exception.UnauthorizedException;
+import com.meongcare.common.error.exception.clientError.InvalidTokenException;
+import com.meongcare.common.error.exception.clientError.UnauthorizedException;
 import com.meongcare.domain.member.domain.entity.Member;
 import com.meongcare.domain.auth.domain.entity.RefreshToken;
 import com.meongcare.domain.member.domain.repository.MemberRepository;

--- a/meongcare/src/main/java/com/meongcare/domain/dog/domain/DogRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/dog/domain/DogRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.dog.domain;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.dog.domain.entity.Dog;
 import com.meongcare.domain.member.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/meongcare/src/main/java/com/meongcare/domain/excreta/domain/repository/ExcretaRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/excreta/domain/repository/ExcretaRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.excreta.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.excreta.domain.entity.Excreta;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/meongcare/src/main/java/com/meongcare/domain/feed/application/FeedService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/application/FeedService.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.feed.application;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.dog.domain.DogRepository;
 import com.meongcare.domain.dog.domain.entity.Dog;
 import com.meongcare.domain.feed.domain.entity.Feed;

--- a/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRecordRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRecordRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.feed.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.feed.domain.entity.FeedRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.feed.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.feed.domain.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/meongcare/src/main/java/com/meongcare/domain/medicalrecord/domain/repository/MedicalRecordRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/medicalrecord/domain/repository/MedicalRecordRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.medicalrecord.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.medicalrecord.domain.entity.MedicalRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/meongcare/src/main/java/com/meongcare/domain/member/application/MemberService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/member/application/MemberService.java
@@ -1,10 +1,6 @@
 package com.meongcare.domain.member.application;
 
-import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
-import com.meongcare.domain.dog.application.DogService;
 import com.meongcare.domain.dog.domain.DogRepository;
-import com.meongcare.domain.dog.domain.entity.Dog;
 import com.meongcare.domain.member.domain.entity.RevokeMember;
 import com.meongcare.domain.member.domain.entity.Member;
 import com.meongcare.domain.member.domain.repository.MemberRepository;
@@ -17,8 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/meongcare/src/main/java/com/meongcare/domain/member/domain/repository/MemberRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/member/domain/repository/MemberRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.member.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.member.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/meongcare/src/main/java/com/meongcare/domain/notice/domain/repository/NoticeRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/notice/domain/repository/NoticeRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.notice.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.notice.domain.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRecordRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRecordRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.supplements.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.supplements.domain.entity.SupplementsRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.supplements.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.supplements.domain.entity.Supplements;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsTimeRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsTimeRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.supplements.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.supplements.domain.entity.SupplementsTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;

--- a/meongcare/src/main/java/com/meongcare/domain/symptom/domain/repository/SymptomRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/symptom/domain/repository/SymptomRepository.java
@@ -1,7 +1,7 @@
 package com.meongcare.domain.symptom.domain.repository;
 
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.symptom.domain.entity.Symptom;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/meongcare/src/main/java/com/meongcare/infra/image/s3/ImageHandlerS3.java
+++ b/meongcare/src/main/java/com/meongcare/infra/image/s3/ImageHandlerS3.java
@@ -2,8 +2,8 @@ package com.meongcare.infra.image.s3;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.meongcare.common.error.ErrorCode;
-import com.meongcare.common.error.exception.EntityNotFoundException;
-import com.meongcare.common.error.exception.FailedFileUploadException;
+import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
+import com.meongcare.common.error.exception.serverError.FailedFileUploadException;
 import com.meongcare.infra.image.ImageDirectory;
 import com.meongcare.infra.image.ImageHandler;
 import lombok.RequiredArgsConstructor;

--- a/meongcare/src/main/java/com/meongcare/infra/message/firebase/MessageHandlerFirebase.java
+++ b/meongcare/src/main/java/com/meongcare/infra/message/firebase/MessageHandlerFirebase.java
@@ -4,6 +4,8 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import com.meongcare.common.error.ErrorCode;
+import com.meongcare.common.error.exception.serverError.MessageException;
 import com.meongcare.infra.message.MessageHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +29,8 @@ public class MessageHandlerFirebase implements MessageHandler {
         try{
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
-            log.error("알림 보내기를 실패하였습니다. errorMessage={}", e.getMessage());
+            log.error("errorMessage = {}", e.getMessage());
+            throw new MessageException(ErrorCode.FAILED_MESSAGE_SEND);
         }
     }
 

--- a/meongcare/src/main/resources/logback-spring.xml
+++ b/meongcare/src/main/resources/logback-spring.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
     <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
-    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
-        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %msg %n</pattern>
-        </layout>
-        <username>Log Bot</username>
-        <iconEmoji>:anger:</iconEmoji>
-        <colorCoding>true</colorCoding>
-    </appender>
 
     <!-- Console appender 설정 -->
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
@@ -18,25 +9,45 @@
         </encoder>
     </appender>
 
-    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="SLACK"/>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ERROR</level>
-        </filter>
-    </appender>
+    <springProfile name="local">
+        <!-- local 프로파일일 때는 로그를 파일에 저장하지 않고, 콘솔에만 출력 -->
+        <root level="INFO">
+            <appender-ref ref="Console" />
+        </root>
+    </springProfile>
 
-    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ERROR</level>
-        </filter>
-        <!-- Optionally add an encoder -->
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
+    <springProfile name="!local">
+        <!-- local이 아닌 다른 프로파일일 때는 Slack과 Sentry에 로그 전송 -->
+        <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+            <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %msg %n</pattern>
+            </layout>
+            <username>Log Bot</username>
+            <iconEmoji>:anger:</iconEmoji>
+            <colorCoding>true</colorCoding>
+        </appender>
 
-    <root level="INFO">
-        <appender-ref ref="Console" />
-        <appender-ref ref="ASYNC_SLACK"/>
-    </root>
+        <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="SLACK"/>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+
+        <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+            <!-- Optionally add an encoder -->
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="Console" />
+            <appender-ref ref="ASYNC_SLACK"/>
+        </root>
+    </springProfile>
 </configuration>

--- a/meongcare/src/main/resources/logback-spring.xml
+++ b/meongcare/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %msg %n</pattern>
+        </layout>
+        <username>Log Bot</username>
+        <iconEmoji>:anger:</iconEmoji>
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <!-- Consol appender 설정 -->
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <!-- Optionally add an encoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="Console" />
+        <appender-ref ref="ASYNC_SLACK"/>
+    </root>
+</configuration>

--- a/meongcare/src/main/resources/logback-spring.xml
+++ b/meongcare/src/main/resources/logback-spring.xml
@@ -11,7 +11,7 @@
         <colorCoding>true</colorCoding>
     </appender>
 
-    <!-- Consol appender 설정 -->
+    <!-- Console appender 설정 -->
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>


### PR DESCRIPTION
### ✅ 작업한 내용
- sentry에서 로그를 바로 슬랙에 보내는건 유료라 logback으로 전송하게 했습니다 (그래서 슬랙에 메세지만 통지합니다)
- 로그 레벨이 ERROR인 로그들만 슬랙과 sentry에서 확인할 수 있게 했고, 500에러들만 ERROR 레벨 로그를 출력하게 하려고 Exception 구조를 변경하게 되었습니다
  ![image](https://github.com/meongCare/meongcare-back/assets/81086966/3f56cae1-8cea-4086-89c2-57fd7ed9987a)
- 수정된 application-dev.yml 노션에 올려두었습니다!  


### ✅ 관련 이슈
- Resolved: #90 
