### PR TITLE
사료 섭취 중단 후 사료 변경 시도 시 처리가능하도록 변경

### DIFF
--- a/meongcare/src/main/java/com/meongcare/domain/feed/application/FeedService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/application/FeedService.java
@@ -95,13 +95,13 @@ public class FeedService {
 
     @Transactional
     public void changeFeed(Long dogId, Long newFeedId) {
-        FeedRecord activateFeedRecord = feedRecordQueryRepository.getActiveFeedRecordByDogId(dogId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FEED_RECORD_ENTITY_NOT_FOUND));
-
-        activateFeedRecord.disActivate();
-        if (Objects.isNull(activateFeedRecord.getEndDate())) {
-            activateFeedRecord.updateEndDate();
-        }
+        feedRecordQueryRepository.getActiveFeedRecordByDogId(dogId)
+                .ifPresent(feedRecord -> {
+                    feedRecord.disActivate();
+                    if (Objects.isNull(feedRecord.getEndDate())) {
+                        feedRecord.updateEndDate();
+                    }
+                });
 
         feedRecordQueryRepository.getFeedRecord(newFeedId)
                 .filter(feedRecord -> {


### PR DESCRIPTION
### ✅ 작업한 내용
-  사료 중단 후 사료 변경 시도 시 활성화 된 기록이 없어서,
활성화 되어 있는 사료 기록이 있는 경우에만 비활성화 처리 로직을 적용하도록 수정했습니다.


### ✅ 관련 이슈
- Resolved: #121 
